### PR TITLE
Adding property file to set jvm parameters

### DIFF
--- a/dynomite-cluster-checker/gradle.properties
+++ b/dynomite-cluster-checker/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=--Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false -server -Xmx2048m -Xms128m 


### PR DESCRIPTION
Jetty runs inside the gradle jvm. At this point, default values are being assumed to run Jetty. This PR is adding a new property file with fixed parameters to JVM load